### PR TITLE
Added "Initial Repository Setup" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ Generated docs can be uploaded for hosting anywhere you like. The examples below
 
 You need to supply the url of your site to the action in the `site_url` option. For GitHub pages, that domain will be `https://USER_OR_ORG_NAME.github.io/REPOSITORY_NAME/`.
 
+## Initial Repository Setup
+
+New repositories on github have defaults that need to be changed before you can use the workflow below.  The two settings below must be changed in the following order:
+
+### Build and Deployment Settings
+
+The default method on new repositories for deployment to github pages is "Deploy from a branch".  As we are using "GitHub Actions", we need to change this setting.
+
+From the repository page in github, select "Settings" from the horizontal tabs, then "Pages" in the vertical column on the left.  Under "Build and deployment", there's "Source".  Change that from "Deploy from a branch" to "GitHub Actions".
+
+### Allow deployment from all branches
+
+The default "github-pages" environment has a protection rule that only allows deployment from the main branch. This rule needs to be removed.
+
+From the same "Settings" menu in the above section, select "Environments" from the vertical menu on the left. In the list of Environments that are shown, select "github-pages".
+
+Under the "Deployment branches" section of the configuration, click the "Remove" button next to the rule that only allows the branch main.
+
 ## Example workflow
 
 In **release.yaml**, in addition the usual [release-bot-action](https://github.com/ponylang/release-bot-action) workflow entries.


### PR DESCRIPTION
As github's default configurations appear to have changed, added a description of actions needed to be taken to enable the example workflow to work.