### PR TITLE
Remove untagged private images

### DIFF
--- a/.github/workflows/update-latest-image.yml
+++ b/.github/workflows/update-latest-image.yml
@@ -67,3 +67,30 @@ jobs:
           type: stream
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  prune-untagged-images:
+    needs:
+      - rebuild-private-latest-image
+
+    name: Prune untagged images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune
+        # v4.1.1
+        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        with:
+          package-name: 'library-documentation-action-v2'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.


### PR DESCRIPTION
Every night, we create a new "latest" image. This ends up leaving a lot of junk behind in the GitHub package UI for our private image that is hosted in the GitHub container registry. There's hundreds of older, never to be used, former "most recent nightly" images. Each is untagged and won't ever be used again (if it was ever used).

This commit adds a steps in the nightly creation workflow to delete all untagged 'library-documentation-action-v2' images except the most recent. We leave one as it is possible that something might reasonably be in the process of pulling down "latest" while we are doing the deletion and don't want to whack any layers that might be needed for that.

This change removes a ton of noise of the GitHub packages UI for 'library-documentation-action-v2' and also stops wasting storage space on GitHub for what we consider to be "junk images".