### PR TITLE
Rename "private" insiders version of this action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifdef config
 endif
 
 ifeq ($(config),private)
-	IMAGE := ghcr.io/ponylang/library-documentation-action-v2
+	IMAGE := ghcr.io/ponylang/library-documentation-action-v2-insiders
 	PACKAGE = "git+https://${MATERIAL_INSIDERS_ACCESS}@github.com/squidfunk/mkdocs-material-insiders.git"
 else
 	IMAGE = ponylang/library-documentation-action-v2


### PR DESCRIPTION
When we move all our images off of DockerHub, we have a problem. The public version of this action on DockerHub and the private version on GHCR have the same name and will conflict.

This commit changes the name of the private version that includes the insiders version of the mkdocs material theme to include "-insiders" at the end to distinguish between them.

Once the new package has latest and release tags available, I'll delete the current package so the name can be reused for the public version and we can start transitioning it from DockerHub to GitHub Container Registry.