### PR TITLE
Upgrade docker/login-action to v4

### DIFF
--- a/.github/workflows/update-nightly-image.yml
+++ b/.github/workflows/update-nightly-image.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/update-release-image.yml
+++ b/.github/workflows/update-release-image.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -56,8 +55,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
The docker/login-action v3 line uses Node.js 20 which is deprecated by GitHub Actions. v4 upgrades to Node.js 24.

Replaces the pinned SHA (v2.2.0) references across both workflow files.