### PR TITLE
Update snok/container-retention-policy to v3.1.0, switch to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/update-nightly-image.yml
+++ b/.github/workflows/update-nightly-image.yml
@@ -53,11 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prune
-        # v3.0.1
-        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        # v3.1.0
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53
         with:
           account: ponylang
-          token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           image-names: library-documentation-action-v2
           tag-selection: untagged
           cut-off: 1d


### PR DESCRIPTION
v3.1.0 fixes the token-validation regex that rejected GitHub's `ghs_` JWT format, so we can switch back from `DELETE_PACKAGES_TOKEN` to `GITHUB_TOKEN`.